### PR TITLE
Feature: Titlebar uses theme colors in single-tab mode

### DIFF
--- a/src/css/editor_chrome.css
+++ b/src/css/editor_chrome.css
@@ -1381,6 +1381,9 @@ canvas.decorationsOverviewRuler {
 .monaco-workbench .part.editor > .content .editor-group-container > .title:not(.tabs) {
     background: var(--card-bg) !important;
     padding-right: var(--s5) !important;
+    > .label-container .monaco-breadcrumbs {
+        background-color: transparent !important;
+    }
 }
 
 :root {

--- a/src/css/editor_chrome.css
+++ b/src/css/editor_chrome.css
@@ -1377,6 +1377,12 @@ canvas.decorationsOverviewRuler {
     border-bottom-right-radius: var(--border-radius) !important;
 }
 
+/* Single Tab mode titlebar */
+.monaco-workbench .part.editor > .content .editor-group-container > .title:not(.tabs) {
+    background: var(--card-bg) !important;
+    padding-right: var(--s5) !important;
+}
+
 :root {
     --flyout-bg: rgba(252, 252, 252, 0.5);
     --menu-bg: rgba(252, 252, 252, 0.5);


### PR DESCRIPTION
The change introduces styling for the single tab mode titlebar in the Monaco workbench.

## Changes

- Synchronized single tab mode titlebar background.
- Added padding to the right of the single tab mode titlebar.
- Updated breadcrumbs background color.

## Screenshots

### Before

Github Dark Default:
![image](https://github.com/user-attachments/assets/db69ffc2-4f43-4e10-b143-c8cd73888aad)
Dark+:
![image](https://github.com/user-attachments/assets/ea63bccd-6f37-4af9-9eca-9eece71250ce)
Tomorrow Night Blue:
![image](https://github.com/user-attachments/assets/43bc6e64-c22d-47fc-9928-84b6061a4318)

### After

Dark+:
![image](https://github.com/user-attachments/assets/8b79d788-bd4a-421c-9a68-d6b02b692e1c)
Tomorrow Night Blue:
![image](https://github.com/user-attachments/assets/2744a03a-7c9b-47ea-95bd-c94b2394fe42)

## Checklist

- [x] Changes are tested locally and work as expected.
- [x] Rendering consistency tested across various themes.

## Related Issue

Resolves: #17
