### PR TITLE
Fix: Correct padding for file/directory input box in Explorer

### DIFF
--- a/src/css/editor_chrome.css
+++ b/src/css/editor_chrome.css
@@ -1377,6 +1377,12 @@ canvas.decorationsOverviewRuler {
     border-bottom-right-radius: var(--border-radius) !important;
 }
 
+/* Creating File/Directory input box  */
+.explorer-folders-view .explorer-item .monaco-inputbox {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+}
+
 :root {
     --flyout-bg: rgba(252, 252, 252, 0.5);
     --menu-bg: rgba(252, 252, 252, 0.5);


### PR DESCRIPTION
This PR resolves a misalignment issue with the file/directory input box in the Explorer's folder view. 

## Changes

- Ensured the input box is visually centered and aligned correctly within its container.
- Resolved alignment issues to improve the overall user experience and consistency.

## Screenshots

### Before

![螢幕擷取畫面 2025-01-07 141826](https://github.com/user-attachments/assets/a08962cf-8e59-40c5-89e8-e3a0eb1b11ab)

### After

![螢幕擷取畫面 2025-01-07 141346](https://github.com/user-attachments/assets/99cc2660-88da-415f-8d9a-ab128a31db78)

## Checklist

- [x] Changes are tested locally and work as expected.
- [x] Rendering consistency tested across various themes.

## Related Issue

Resolves: #10 
