### PR TITLE
Fix: Remove padding from bottom panel input box

### DIFF
--- a/src/css/editor_chrome.css
+++ b/src/css/editor_chrome.css
@@ -1071,6 +1071,12 @@ html {
     box-shadow: var(--depth-2);
 }
 
+/* Remove padding from bottom panel input box to make it horizontal center */
+.viewpane-filter-container > .viewpane-filter .monaco-inputbox > .ibwrapper > .input {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+}
+
 /* Tooltips */
 .workbench-hover {
     background-color: var(--noise-bg) repeat var(--hover-bg) !important;


### PR DESCRIPTION
This PR resolves a misalignment issue with the input box in the bottom panel.

## Changes

- Eliminate top and bottom padding for horizontal centering
- Target specific CSS selectors to adjust input box styling

## Screenshots

### Before

![Image](https://github.com/user-attachments/assets/27634ebb-5c51-4609-a2f9-e20f942a99a0)

### After

![image](https://github.com/user-attachments/assets/a9c8769a-b602-437b-b826-f69cf4b8302b)

## Related Issue

Resolves: #38 
