### PR TITLE
fix: prevent commit message parsing issues in auto tag workflow

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -64,12 +64,14 @@ jobs:
             - name: Create and push tag
               if: ${{ steps.version_info.outputs.error == 'false' }}
               run: |
-                  tag_name="${{ steps.validate_version.outputs.TAG_NAME }}"
-                  commit_message="${{ steps.version_info.outputs.COMMIT_MESSAGE }}"
-
                   echo "::notice::Creating tag $tag_name"
 
-                  if git tag -a "$tag_name" -m "$commit_message" && git push origin "$tag_name"; then
+                  tag_name="${{ steps.validate_version.outputs.TAG_NAME }}"
+                  cat > tag_message.txt << EOF
+                    ${{ steps.version_info.outputs.COMMIT_MESSAGE }}
+                  EOF
+
+                  if git tag -a "$tag_name" -F tag_message.txt && git push origin "$tag_name"; then
                     echo "::notice::Successfully created and pushed tag $tag_name"
                   else
                     echo "::error::Failed to create or push tag $tag_name"

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -63,11 +63,13 @@ jobs:
 
             - name: Create and push tag
               if: ${{ steps.version_info.outputs.error == 'false' }}
+              env:
+                  GITHUB_TOKEN: ${{ secrets.TAG_PAT }} # Use PAT for tagging subsequent ci workflows, not the default
               run: |
                   echo "::notice::Creating tag $tag_name"
 
                   tag_name="${{ steps.validate_version.outputs.TAG_NAME }}"
-                  cat > tag_message.txt << EOF
+                  cat > tag_message.txt << 'EOF'
                     ${{ steps.version_info.outputs.COMMIT_MESSAGE }}
                   EOF
 


### PR DESCRIPTION
This PR fixes an issue in the GitHub Actions auto tag workflow where commit messages containing backticks (\`), special characters, or multi-line content could cause tag creation to fail.

## Changes

###  Fix commit message handling  
- Previously, the `commit_message` was passed directly to `git tag -m`, which caused parsing issues when the message contained special characters like backticks (\`) or multi-line content.  
- Now the message is safely written to a **temporary file** (`tag_message.txt`), and `git tag -F` is used to read the message.  
  This prevents accidental evaluation or escaping issues.

###  Use Personal Access Token (PAT) for pushing tags  
- Introduced the `GITHUB_TOKEN: ${{ secrets.TAG_PAT }}` environment variable for the tag-pushing step.  
  This ensures subsequent workflows are triggered when a tag is pushed—something the default GitHub token can’t always do.

## Why
- Fixes failures when commit messages include backticks (\`), special characters, or multi-line text.  
- Ensures that `git tag` correctly processes the message without unintended parsing or escaping issues.  
- Uses a PAT to guarantee workflow triggers after pushing tags.
