### PR TITLE
docs: update README for Marketplace & Open VSX publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,28 @@
         alt="Latest Release"
       />
     </a>
-    <img
-      src="https://img.shields.io/github/downloads/Night-Star04/vscode-fluent-ui/total?style=for-the-badge&logo=github&logoColor=white&label=Downloads"
-      alt="GitHub Downloads (all release)"
-    />
-    <img
+   <img
       src="https://img.shields.io/github/issues/Night-Star04/vscode-fluent-ui?style=for-the-badge&logo=github&logoColor=white&label=Issues"
       alt="GitHub Issues"
     />
+    <br/>
+    <img
+      src="https://img.shields.io/github/downloads/Night-Star04/vscode-fluent-ui/total?style=for-the-badge&logo=github&logoColor=white&label=GitHub%20Release"
+      alt="GitHub Downloads"
+    />
+    <a href="https://marketplace.visualstudio.com/items?itemName=NightSky-Studio.vscode-fluent-ui-continued">
+      <img
+        src="https://img.shields.io/visual-studio-marketplace/i/NightSky-Studio.vscode-fluent-ui-continued?style=for-the-badge&logo=codecrafters&logoColor=007ACC&label=Visual%20Studio%20Marketplace"
+        alt="Visual Studio Marketplace Installs"
+      />
+    </a>
+    <a href="https://open-vsx.org/extension/NightSky-Studio/vscode-fluent-ui-continued">
+      <img
+        src="https://img.shields.io/open-vsx/dt/NightSky-Studio/vscode-fluent-ui-continued?style=for-the-badge&logo=vscodium&logoColor=#2F80ED&label=Open%20VSX"
+        alt="Open VSX Downloads"
+      />
+    </a>
+    <br/>
   </div>
 </div>
 
@@ -88,6 +102,63 @@ Inspired by and based on the awesome concept designs by
 
 ## Installation
 
+<details open>
+<summary><h3>Visual Studio Marketplace (Recommended)</h3></summary>
+
+1. Open the extensions view (`Ctrl+Shift+X`) for Visual Studio Code
+2. Search for `Fluent UI (continued)` or `NightSky-Studio.vscode-fluent-ui-continued`
+3. Click the "Install" button for the "Fluent UI for VSCode (Continued)" extension by
+   NightSky-Studio
+4. Configure the extension settings (optional)
+
+    - Open the settings view (`Ctrl+,`)
+    - Search for `@ext:NightSky-Studio.vscode-fluent-ui-continued`
+    - Adjust the settings to your preference
+
+5. Enable the extension
+
+    - Open the command palette (`Ctrl+Shift+P`)
+    - Run the command `> Fluent: Enable`
+    - Wait for the command to finish
+    - Reload the window when prompted
+
+6. Enjoy the Fluent UI theme!
+
+> Direct link:
+> [Visual Studio Marketplace - Fluent UI](https://marketplace.visualstudio.com/items?itemName=NightSky-Studio.vscode-fluent-ui-continued)
+
+</details>
+
+<details>
+<summary><h3>Open VSX Registry</h3></summary>
+
+1. Open the extensions view (`Ctrl+Shift+X`) for your VS Code compatible editor (like VSCodium)
+2. Search for `Fluent UI (continued)` or `NightSky-Studio.vscode-fluent-ui-continued`
+3. Click the "Install" button for the "Fluent UI for VSCode (Continued)" extension by
+   NightSky-Studio
+4. Configure the extension settings (optional)
+
+    - Open the settings view (`Ctrl+,`)
+    - Search for `@ext:NightSky-Studio.vscode-fluent-ui-continued`
+    - Adjust the settings to your preference
+
+5. Enable the extension
+
+    - Open the command palette (`Ctrl+Shift+P`)
+    - Run the command `> Fluent: Enable`
+    - Wait for the command to finish
+    - Reload the window when prompted
+
+6. Enjoy the Fluent UI theme!
+
+> Direct link:
+> [Open VSX Registry - Fluent UI](https://open-vsx.org/extension/NightSky-Studio/vscode-fluent-ui-continued)
+
+</details>
+
+<details>
+<summary><h3>GitHub Release</h3></summary>
+
 1. Download the latest version of the installation file from
    [Releases](https://github.com/Night-Star04/vscode-fluent-ui/releases/latest)
 2. Run Visual Studio Code as administrator
@@ -103,7 +174,7 @@ Inspired by and based on the awesome concept designs by
 4. Configure the extension settings (optional)
 
     - Open the settings view (`Ctrl+,`)
-    - Search for `@ext:NightSky-Studio.vscode-fluent-ui`
+    - Search for `@ext:NightSky-Studio.vscode-fluent-ui-continued`
     - Adjust the settings to your preference
 
     > If you don't see the settings, make sure you have the extension enabled
@@ -115,13 +186,9 @@ Inspired by and based on the awesome concept designs by
     - Wait for the command to finish
     - Reload the window when prompted
 
-6. Handle "Corrupt installation" warning
+6. Enjoy the Fluent UI theme!
 
-    - Click the cog icon on the notification
-    - Select `Don't show again`
-    - You should be good to go
-
-7. Enjoy the Fluent UI theme!
+</details>
 
 > [!TIP]
 >
@@ -153,7 +220,7 @@ Inspired by and based on the awesome concept designs by
     - Click `Uninstall`
 
     > You can also uninstall it via the command line with
-    > `code --uninstall-extension NightSky-Studio.vscode-fluent-ui`
+    > `code --uninstall-extension NightSky-Studio.vscode-fluent-ui-continued`
 
 4. Enjoy the default VS Code theme!
 
@@ -193,13 +260,19 @@ Details on the available settings can be found in the [Settings](/STEEING.md) pa
 This section only covers the most common issues. If you encounter any other problems, please check
 the [Troubleshooting](/TROUBLESHOOTING.md) page or open an new issue on the github.
 
-1. **Why does the corrupt installation warning appear?**
+1. **Show Corrupt installation warning after installing the extension.**
 
     This is normal, don't worry. This is expected behavior and is necessary for the extension to
     work.
 
     When you install the extension, extensions modify the workbench html file to apply the theme.
     Visual Studio Code sees the installation as corrupt because the file has been modified.
+
+    If you want to get rid of this message, please follow the steps below:
+
+    1. Click on the cog icon on the notification
+    2. Select `Don't show again`
+    3. You should be good to go
 
 2. **Why can’t I use the default theme’s visual studio code normally after uninstalling it?**
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
   </div>
 </div>
 
-<div align="center">English | <a href="README-zh-TW.md">繁體中文</a></div>
+<div align="center">English | <a href="README.zh-TW.md">繁體中文</a></div>
 
 Enhance your Visual Studio Code experience with a modern, Fluent UI-inspired theme.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
     </a>
     <a href="https://open-vsx.org/extension/NightSky-Studio/vscode-fluent-ui-continued">
       <img
-        src="https://img.shields.io/open-vsx/dt/NightSky-Studio/vscode-fluent-ui-continued?style=for-the-badge&logo=vscodium&logoColor=#2F80ED&label=Open%20VSX"
+        src="https://img.shields.io/open-vsx/dt/NightSky-Studio/vscode-fluent-ui-continued?style=for-the-badge&logo=vscodium&logoColor=2F80ED&label=Open%20VSX"
         alt="Open VSX Downloads"
       />
     </a>

--- a/README.md
+++ b/README.md
@@ -12,28 +12,36 @@
         alt="Latest Release"
       />
     </a>
-   <img
+    <img
       src="https://img.shields.io/github/issues/Night-Star04/vscode-fluent-ui?style=for-the-badge&logo=github&logoColor=white&label=Issues"
       alt="GitHub Issues"
     />
-    <br/>
+    <img
+      src="https://img.shields.io/github/release-date/Night-Star04/vscode-fluent-ui?style=for-the-badge&logo=github&logoColor=white&label=Last%20Release"
+      alt="Last Release Date"
+    />
+    <br />
     <img
       src="https://img.shields.io/github/downloads/Night-Star04/vscode-fluent-ui/total?style=for-the-badge&logo=github&logoColor=white&label=GitHub%20Release"
       alt="GitHub Downloads"
     />
-    <a href="https://marketplace.visualstudio.com/items?itemName=NightSky-Studio.vscode-fluent-ui-continued">
+    <a
+      href="https://marketplace.visualstudio.com/items?itemName=NightSky-Studio.vscode-fluent-ui-continued"
+    >
       <img
         src="https://img.shields.io/visual-studio-marketplace/i/NightSky-Studio.vscode-fluent-ui-continued?style=for-the-badge&logo=codecrafters&logoColor=007ACC&label=Visual%20Studio%20Marketplace"
         alt="Visual Studio Marketplace Installs"
       />
     </a>
-    <a href="https://open-vsx.org/extension/NightSky-Studio/vscode-fluent-ui-continued">
+    <a
+      href="https://open-vsx.org/extension/NightSky-Studio/vscode-fluent-ui-continued"
+    >
       <img
         src="https://img.shields.io/open-vsx/dt/NightSky-Studio/vscode-fluent-ui-continued?style=for-the-badge&logo=vscodium&logoColor=2F80ED&label=Open%20VSX"
         alt="Open VSX Downloads"
       />
     </a>
-    <br/>
+    <br />
   </div>
 </div>
 
@@ -370,6 +378,6 @@ This project is licensed under the MIT License - see the [LICENSE](/LICENSE) fil
 
 ---
 
-_Give your Visual Studio Code a modern, Fluent UI-inspired makeover today!_
+_✨ Give your Visual Studio Code a modern, Fluent UI-inspired makeover today!_
 
-_If you like this fluently themed extension, please consider giving it a ⭐!_
+_⭐ If you like this fluently themed extension, please consider giving it a star!_

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -12,14 +12,28 @@
         alt="Latest Release"
       />
     </a>
-    <img
-      src="https://img.shields.io/github/downloads/Night-Star04/vscode-fluent-ui/total?style=for-the-badge&logo=github&logoColor=white&label=Downloads"
-      alt="GitHub Downloads (all release)"
-    />
-    <img
+   <img
       src="https://img.shields.io/github/issues/Night-Star04/vscode-fluent-ui?style=for-the-badge&logo=github&logoColor=white&label=Issues"
       alt="GitHub Issues"
     />
+    <br/>
+    <img
+      src="https://img.shields.io/github/downloads/Night-Star04/vscode-fluent-ui/total?style=for-the-badge&logo=github&logoColor=white&label=GitHub%20Release"
+      alt="GitHub Downloads"
+    />
+    <a href="https://marketplace.visualstudio.com/items?itemName=NightSky-Studio.vscode-fluent-ui-continued">
+      <img
+        src="https://img.shields.io/visual-studio-marketplace/i/NightSky-Studio.vscode-fluent-ui-continued?style=for-the-badge&logo=codecrafters&logoColor=007ACC&label=Visual%20Studio%20Marketplace"
+        alt="Visual Studio Marketplace Installs"
+      />
+    </a>
+    <a href="https://open-vsx.org/extension/NightSky-Studio/vscode-fluent-ui-continued">
+      <img
+        src="https://img.shields.io/open-vsx/dt/NightSky-Studio/vscode-fluent-ui-continued?style=for-the-badge&logo=vscodium&logoColor=2F80ED&label=Open%20VSX"
+        alt="Open VSX Downloads"
+      />
+    </a>
+    <br/>
   </div>
 </div>
 
@@ -86,6 +100,63 @@ VS Code Fluent UI 是一個主題套件，將微軟 Fluent UI 設計的流暢美
 
 ## 安裝
 
+<details open>
+<summary><h3>Visual Studio Marketplace (推薦)</h3></summary>
+
+1. 開啟 Visual Studio Code
+2. 開啟延伸模組視窗 (`Ctrl+Shift+X`)
+3. 搜尋 `Fluent UI (continued)` 或 `NightSky-Studio.vscode-fluent-ui-continued`
+4. 點擊 "安裝" 按鈕安裝由 NightSky-Studio 開發的 "Fluent UI for VSCode (Continued)" 延伸模組
+5. 設定延伸模組 (選用)
+    - 開啟設定 (`Ctrl+,`)
+    - 搜尋 `@ext:NightSky-Studio.vscode-fluent-ui-continued`
+    - 根據個人喜好調整設定
+6. 啟用延伸模組
+    - 開啟命令面板 (`Ctrl+Shift+P`)
+    - 執行命令 `> Fluent: Enable`
+    - 等待命令完成
+    - 在提示時重新載入視窗
+7. 處理「安裝損壞」警告
+    - 點擊通知上的齒輪圖標
+    - 選擇 `不再顯示`
+    - 完成設定
+8. 享受 Fluent UI 主題！
+
+> 直接連結
+> ：[Visual Studio Marketplace - Fluent UI](https://marketplace.visualstudio.com/items?itemName=NightSky-Studio.vscode-fluent-ui-continued)
+
+</details>
+
+<details>
+<summary><h3>Open VSX Registry</h3></summary>
+
+1. 開啟您的 VS Code 相容編輯器（如 VSCodium）
+2. 開啟延伸模組視窗 (`Ctrl+Shift+X`)
+3. 搜尋 `Fluent UI (continued)` 或 `NightSky-Studio.vscode-fluent-ui-continued`
+4. 點擊 "安裝" 按鈕安裝由 NightSky-Studio 開發的 "Fluent UI for VSCode (Continued)" 延伸模組
+5. 設定延伸模組 (選用)
+    - 開啟設定 (`Ctrl+,`)
+    - 搜尋 `@ext:NightSky-Studio.vscode-fluent-ui-continued`
+    - 根據個人喜好調整設定
+6. 啟用延伸模組
+    - 開啟命令面板 (`Ctrl+Shift+P`)
+    - 執行命令 `> Fluent: Enable`
+    - 等待命令完成
+    - 在提示時重新載入視窗
+7. 處理「安裝損壞」警告
+    - 點擊通知上的齒輪圖標
+    - 選擇 `不再顯示`
+    - 完成設定
+8. 享受 Fluent UI 主題！
+
+> 直接連結
+> ：[Open VSX Registry - Fluent UI](https://open-vsx.org/extension/NightSky-Studio/vscode-fluent-ui-continued)
+
+</details>
+
+<details>
+<summary><h3>GitHub Release</h3></summary>
+
 1. 從 [Releases](https://github.com/Night-Star04/vscode-fluent-ui/releases/latest) 下載最新版本的安
    裝文件
 2. 以管理員身份運行 Visual Studio Code
@@ -131,6 +202,8 @@ VS Code Fluent UI 是一個主題套件，將微軟 Fluent UI 設計的流暢美
 > 這一點。
 >
 > 您可以通過在設置頁面中取消選中 `Enable background image` 來禁用此功能。
+
+</details>
 
 ## 解除安裝
 
@@ -188,21 +261,27 @@ VS Code Fluent UI 是一個主題套件，將微軟 Fluent UI 設計的流暢美
 此部分僅涵蓋最常見的問題。如果您遇到其他問題，請查看 [疑難解答](/TROUBLESHOOTING.md) 頁面或在 Github
 中打開問題。
 
-1.  **為什麼會出現安裝損壞警告？**
+1. **安裝延伸模組後顯示安裝損壞警告**
 
     這是正常的，不用擔心。這是預期行為，並且是套件正常運行所必需的。
 
     當您安裝套件時，套件會修改工作台 html 文件以應用主題。 Visual Studio Code 認為安裝已損壞，因為文
     件已被修改。
 
-2.  **為什麼在卸載後無法正常使用默認主題的 Visual Studio Code？**
+    如果您想要移除此訊息，請按照以下步驟操作：
+
+    1. 點擊通知上的齒輪圖標
+    2. 選擇 `不再顯示`
+    3. 完成設定
+
+2. **為什麼在卸載後無法正常使用默認主題的 Visual Studio Code？**
 
     這是可能的，但機會很小。
 
     如果您遇到此問題，請按照以下步驟修復。請參閱 [解除安裝](/TROUBLESHOOTING.md#uninstallation) 部分
     以獲取進一步說明。
 
-3.  **我可以與其他套件一起使用嗎？**
+3. **我可以與其他套件一起使用嗎？**
 
     是的，您可以將此主題與其他套件一起使用。但是，某些套件可能與此主題不兼容。
 
@@ -214,19 +293,29 @@ VS Code Fluent UI 是一個主題套件，將微軟 Fluent UI 設計的流暢美
 ### 最新版本變更
 
 ```markdown
-Version 4.3.0 (2024-11-01)
+# [4.6.0] - 2025-03-11
 
-# Fixed
+## 🐛 Fixes
 
--   Fixed an issue where the extension could not run properly.
--   Fixed an issue where the source control sidebar was appearing beneath the code view.
+-   Correctly display content tooltip on editor container hover (#37)
+-   Remove padding from bottom panel input box (#39)
 
-# Chore
+## 🛠️ Dependency Updates
 
--   Updated import statements and function calls.
--   Improved error handling and resolved test running errors.
--   Updated ESLint configuration and package settings.
--   Removed unused code and related files.
+-   Upgrade `sharp` from `0.32.1` to `0.33.5`
+-   Upgrade `@types/mocha` from `10.0.9` to `10.0.10`
+-   Upgrade `@typescript-eslint/eslint-plugin` from `8.10.0` to `8.25.0`
+-   Upgrade `@typescript-eslint/parser` from `8.7.0` to `8.25.0`
+-   Upgrade `@vscode/vsce` from `3.2.1` to `3.2.2`
+-   Upgrade `esbuild` from `0.17.19` to `0.25.0`
+-   Upgrade `eslint` from `9.13.0` to `9.21.0`
+-   Upgrade `glob` from `10.2.3` to `11.0.1`
+-   Upgrade `mocha` from `11.0.1` to `11.1.0`
+-   Upgrade `typescript` from `5.6.3` to `5.7.3`
+
+## 🧹 Dependency Cleanup
+
+-   Removed unused dependencies: `file-url`, `node-fetch`, `@types/node-fetch`
 ```
 
 您可以在 [更新日誌](/CHANGELOG.md) 頁面找到完整的更新日誌。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -12,28 +12,36 @@
         alt="Latest Release"
       />
     </a>
-   <img
+    <img
       src="https://img.shields.io/github/issues/Night-Star04/vscode-fluent-ui?style=for-the-badge&logo=github&logoColor=white&label=Issues"
       alt="GitHub Issues"
     />
-    <br/>
+    <img
+      src="https://img.shields.io/github/release-date/Night-Star04/vscode-fluent-ui?style=for-the-badge&logo=github&logoColor=white&label=Last%20Release"
+      alt="Last Release Date"
+    />
+    <br />
     <img
       src="https://img.shields.io/github/downloads/Night-Star04/vscode-fluent-ui/total?style=for-the-badge&logo=github&logoColor=white&label=GitHub%20Release"
       alt="GitHub Downloads"
     />
-    <a href="https://marketplace.visualstudio.com/items?itemName=NightSky-Studio.vscode-fluent-ui-continued">
+    <a
+      href="https://marketplace.visualstudio.com/items?itemName=NightSky-Studio.vscode-fluent-ui-continued"
+    >
       <img
         src="https://img.shields.io/visual-studio-marketplace/i/NightSky-Studio.vscode-fluent-ui-continued?style=for-the-badge&logo=codecrafters&logoColor=007ACC&label=Visual%20Studio%20Marketplace"
         alt="Visual Studio Marketplace Installs"
       />
     </a>
-    <a href="https://open-vsx.org/extension/NightSky-Studio/vscode-fluent-ui-continued">
+    <a
+      href="https://open-vsx.org/extension/NightSky-Studio/vscode-fluent-ui-continued"
+    >
       <img
         src="https://img.shields.io/open-vsx/dt/NightSky-Studio/vscode-fluent-ui-continued?style=for-the-badge&logo=vscodium&logoColor=2F80ED&label=Open%20VSX"
         alt="Open VSX Downloads"
       />
     </a>
-    <br/>
+    <br />
   </div>
 </div>
 
@@ -368,6 +376,6 @@ VS Code Fluent UI 是一個主題套件，將微軟 Fluent UI 設計的流暢美
 
 ---
 
-_今天就給你的 Visual Studio Code 一個現代、Fluent UI 風格的裝扮吧！_
+_✨ 今天就給你的 Visual Studio Code 一個現代、Fluent UI 風格的裝扮吧！_
 
-_如果你喜歡這個 Fluent UI 的套件，請考慮給它一個 ⭐！_
+_⭐ 如果你喜歡這個 Fluent UI 的套件，請考慮給它一個星星！_


### PR DESCRIPTION
This pull request updates both the English and Traditional Chinese `README` files to reflect the latest publishing of the extension on the **Visual Studio Marketplace** and **Open VSX Registry**.

## Changes

### 📄 Documentation Updates

- **Publishing Information**
  - Added badges and links for:
    - Visual Studio Marketplace
    - Open VSX Registry
    - GitHub Release
- **Installation Instructions**

  - Detailed guides for installing from:
    - Visual Studio Marketplace (Recommended)
    - Open VSX Registry
    - GitHub Releases

- **Badges**
  - Added new badges for:
    - Marketplace installs
    - Open VSX downloads
    - Latest release date
  - Cleaned up badge layout and labels for consistency.

### 🗃️ Chore

- **File Renaming**
  - Renamed `README-zh-TW.md` → `README.zh-TW.md` for consistency and clarity.

### 📝 Localization

- Synchronized Traditional Chinese `README` (`README.zh-TW.md`) with the English version:
  - Publishing details
  - Installation guides
  - Badges and layout improvements

## Why

Now that the extension is published on both the **Visual Studio Marketplace** and **Open VSX Registry**, it's important to reflect these updates in the README. This provides users with clear installation paths and ensures they are aware of the different distribution options.

## Related Issue

Resolves: #50 
