### PR TITLE
feat: Add support for secondary sidebar layout

### DIFF
--- a/src/css/editor_chrome.css
+++ b/src/css/editor_chrome.css
@@ -1430,7 +1430,6 @@ canvas.decorationsOverviewRuler {
 /* Secondary sidebar */
 .monaco-workbench .part.auxiliarybar {
     background: transparent !important;
-    background-blend-mode: exclusion;
     overflow-y: auto;
     height: var(--content-height);
 
@@ -1441,11 +1440,9 @@ canvas.decorationsOverviewRuler {
 
         > .composite-bar-container .action-item {
             border-radius: var(--border-radius) var(--border-radius) 0 0 !important;
-            border-top: transparent !important;
             border: 1px solid transparent !important;
-            transition: borderRadius var(--easing-timing-fast) var(--easing-curve-in),
+            transition: border-radius var(--easing-timing-fast) var(--easing-curve-in),
                 transform var(--easing-timing-fast) var(--easing-curve-in);
-            will-change: borderRadius;
         }
         .action-item {
             overflow: hidden;

--- a/src/css/editor_chrome.css
+++ b/src/css/editor_chrome.css
@@ -36,11 +36,14 @@
     --depth-2: 0 0 2px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.14);
     --depth-4: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
     /* Cards */
-    --depth-8: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108); /* Command bars/Command dropdowns/Context menus */
-    --depth-16: 0 6.4px 14.4px 0 rgba(0, 0, 0, 0.132), 0 1.2px 3.6px 0 rgba(0, 0, 0, 0.108); /*Hover cards
+    --depth-8:
+        0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108); /* Command bars/Command dropdowns/Context menus */
+    --depth-16:
+        0 6.4px 14.4px 0 rgba(0, 0, 0, 0.132), 0 1.2px 3.6px 0 rgba(0, 0, 0, 0.108); /*Hover cards
 Tooltips */
     --depth-28: 0 0 8px rgba(0, 0, 0, 0.12), 0 14px 28px rgba(0, 0, 0, 0.14);
-    --depth-64: 0 25.6px 57.6px 0 rgba(0, 0, 0, 0.22), 0 4.8px 14.4px 0 rgba(0, 0, 0, 0.18); /* Panels/Dialogs/Popups */
+    --depth-64:
+        0 25.6px 57.6px 0 rgba(0, 0, 0, 0.22), 0 4.8px 14.4px 0 rgba(0, 0, 0, 0.18); /* Panels/Dialogs/Popups */
 
     /* The following variables are dynamic */
     --accent: ACCENT_COLOR;
@@ -96,7 +99,8 @@ Tooltips */
 
     --notification-toast-bg: var(--flyout-bg);
     --notification-border-radius: 6px;
-    --notification-transition: opacity var(--easing-timing-fast) var(--easing-curve-in),
+    --notification-transition:
+        opacity var(--easing-timing-fast) var(--easing-curve-in),
         transform var(--easing-timing-fast) var(--easing-curve-in);
 
     --quick-input-widget-bg: var(--flyout-bg);
@@ -266,7 +270,8 @@ html {
     padding-right: var(--s4) !important;
     position: relative;
     transition: borderColor var(--easing-timing-fast) var(--easing-curve-in);
-    transition: borderRadius var(--easing-timing-fast) var(--easing-curve-in),
+    transition:
+        borderRadius var(--easing-timing-fast) var(--easing-curve-in),
         transform var(--easing-timing-fast) var(--easing-curve-in);
     will-change: borderRadius;
     z-index: 1;
@@ -290,7 +295,8 @@ html {
     z-index: -1;
     border-top-left-radius: var(--border-radius);
     border-top-right-radius: var(--border-radius);
-    transition: transform var(--easing-timing-fast) var(--easing-curve-in),
+    transition:
+        transform var(--easing-timing-fast) var(--easing-curve-in),
         opacity var(--easing-timing-fast) var(--easing-curve-in);
 }
 
@@ -441,7 +447,8 @@ html {
     z-index: -1;
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
-    transition: transform var(--easing-timing-fast) var(--easing-curve-in),
+    transition:
+        transform var(--easing-timing-fast) var(--easing-curve-in),
         opacity var(--easing-timing-fast) var(--easing-curve-in);
     margin: 0 !important;
 }
@@ -584,7 +591,8 @@ html {
 }
 
 .monaco-list-rows .monaco-list-row {
-    transition: background var(--easing-timing-normal) var(--easing-curve-in),
+    transition:
+        background var(--easing-timing-normal) var(--easing-curve-in),
         color var(--easing-timing-normal) var(--easing-curve-in);
 }
 
@@ -601,7 +609,8 @@ html {
     transform: translateY(-6px) scaleY(0);
     opacity: 0;
     transform-origin: center;
-    transition: transform var(--easing-timing-faster) var(--easing-curve-in),
+    transition:
+        transform var(--easing-timing-faster) var(--easing-curve-in),
         opacity var(--easing-timing-faster) var(--easing-curve-in);
     transition-delay: 25ms;
     z-index: 1;
@@ -782,7 +791,8 @@ html {
 .monaco-action-bar .action-item {
     background: transparent;
     border-radius: var(--s3) !important;
-    transition: background var(--easing-timing-fast) var(--easing-curve-in),
+    transition:
+        background var(--easing-timing-fast) var(--easing-curve-in),
         color var(--easing-timing-faster) var(--easing-curve-in);
 }
 
@@ -815,7 +825,8 @@ html {
     transform: translateY(-10px) scaleY(0);
     opacity: 0;
     transform-origin: center;
-    transition: transform var(--easing-timing-faster) var(--easing-curve-in),
+    transition:
+        transform var(--easing-timing-faster) var(--easing-curve-in),
         opacity var(--easing-timing-faster) var(--easing-curve-in);
     transition-delay: 25ms;
 }
@@ -1441,13 +1452,9 @@ canvas.decorationsOverviewRuler {
         > .composite-bar-container .action-item {
             border-radius: var(--border-radius) var(--border-radius) 0 0 !important;
             border: 1px solid transparent !important;
-            transition: border-radius var(--easing-timing-fast) var(--easing-curve-in),
+            transition:
+                border-radius var(--easing-timing-fast) var(--easing-curve-in),
                 transform var(--easing-timing-fast) var(--easing-curve-in);
-        }
-        .action-item {
-            overflow: hidden;
-            position: relative;
-            z-index: 1;
         }
     }
 

--- a/src/css/editor_chrome.css
+++ b/src/css/editor_chrome.css
@@ -36,14 +36,11 @@
     --depth-2: 0 0 2px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.14);
     --depth-4: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
     /* Cards */
-    --depth-8:
-        0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108); /* Command bars/Command dropdowns/Context menus */
-    --depth-16:
-        0 6.4px 14.4px 0 rgba(0, 0, 0, 0.132), 0 1.2px 3.6px 0 rgba(0, 0, 0, 0.108); /*Hover cards
+    --depth-8: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108); /* Command bars/Command dropdowns/Context menus */
+    --depth-16: 0 6.4px 14.4px 0 rgba(0, 0, 0, 0.132), 0 1.2px 3.6px 0 rgba(0, 0, 0, 0.108); /*Hover cards
 Tooltips */
     --depth-28: 0 0 8px rgba(0, 0, 0, 0.12), 0 14px 28px rgba(0, 0, 0, 0.14);
-    --depth-64:
-        0 25.6px 57.6px 0 rgba(0, 0, 0, 0.22), 0 4.8px 14.4px 0 rgba(0, 0, 0, 0.18); /* Panels/Dialogs/Popups */
+    --depth-64: 0 25.6px 57.6px 0 rgba(0, 0, 0, 0.22), 0 4.8px 14.4px 0 rgba(0, 0, 0, 0.18); /* Panels/Dialogs/Popups */
 
     /* The following variables are dynamic */
     --accent: ACCENT_COLOR;
@@ -99,8 +96,7 @@ Tooltips */
 
     --notification-toast-bg: var(--flyout-bg);
     --notification-border-radius: 6px;
-    --notification-transition:
-        opacity var(--easing-timing-fast) var(--easing-curve-in),
+    --notification-transition: opacity var(--easing-timing-fast) var(--easing-curve-in),
         transform var(--easing-timing-fast) var(--easing-curve-in);
 
     --quick-input-widget-bg: var(--flyout-bg);
@@ -270,8 +266,7 @@ html {
     padding-right: var(--s4) !important;
     position: relative;
     transition: borderColor var(--easing-timing-fast) var(--easing-curve-in);
-    transition:
-        borderRadius var(--easing-timing-fast) var(--easing-curve-in),
+    transition: borderRadius var(--easing-timing-fast) var(--easing-curve-in),
         transform var(--easing-timing-fast) var(--easing-curve-in);
     will-change: borderRadius;
     z-index: 1;
@@ -295,8 +290,7 @@ html {
     z-index: -1;
     border-top-left-radius: var(--border-radius);
     border-top-right-radius: var(--border-radius);
-    transition:
-        transform var(--easing-timing-fast) var(--easing-curve-in),
+    transition: transform var(--easing-timing-fast) var(--easing-curve-in),
         opacity var(--easing-timing-fast) var(--easing-curve-in);
 }
 
@@ -447,8 +441,7 @@ html {
     z-index: -1;
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
-    transition:
-        transform var(--easing-timing-fast) var(--easing-curve-in),
+    transition: transform var(--easing-timing-fast) var(--easing-curve-in),
         opacity var(--easing-timing-fast) var(--easing-curve-in);
     margin: 0 !important;
 }
@@ -591,8 +584,7 @@ html {
 }
 
 .monaco-list-rows .monaco-list-row {
-    transition:
-        background var(--easing-timing-normal) var(--easing-curve-in),
+    transition: background var(--easing-timing-normal) var(--easing-curve-in),
         color var(--easing-timing-normal) var(--easing-curve-in);
 }
 
@@ -609,8 +601,7 @@ html {
     transform: translateY(-6px) scaleY(0);
     opacity: 0;
     transform-origin: center;
-    transition:
-        transform var(--easing-timing-faster) var(--easing-curve-in),
+    transition: transform var(--easing-timing-faster) var(--easing-curve-in),
         opacity var(--easing-timing-faster) var(--easing-curve-in);
     transition-delay: 25ms;
     z-index: 1;
@@ -791,8 +782,7 @@ html {
 .monaco-action-bar .action-item {
     background: transparent;
     border-radius: var(--s3) !important;
-    transition:
-        background var(--easing-timing-fast) var(--easing-curve-in),
+    transition: background var(--easing-timing-fast) var(--easing-curve-in),
         color var(--easing-timing-faster) var(--easing-curve-in);
 }
 
@@ -825,8 +815,7 @@ html {
     transform: translateY(-10px) scaleY(0);
     opacity: 0;
     transform-origin: center;
-    transition:
-        transform var(--easing-timing-faster) var(--easing-curve-in),
+    transition: transform var(--easing-timing-faster) var(--easing-curve-in),
         opacity var(--easing-timing-faster) var(--easing-curve-in);
     transition-delay: 25ms;
 }
@@ -1436,6 +1425,49 @@ canvas.decorationsOverviewRuler {
     > .label-container .monaco-breadcrumbs {
         background-color: transparent !important;
     }
+}
+
+/* Secondary sidebar */
+.monaco-workbench .part.auxiliarybar {
+    background: transparent !important;
+    background-blend-mode: exclusion;
+    overflow-y: auto;
+    height: var(--content-height);
+
+    > .composite.title {
+        background-color: transparent;
+        padding-left: var(--s4) !important;
+        padding-right: 0 !important;
+
+        > .composite-bar-container .action-item {
+            border-radius: var(--border-radius) var(--border-radius) 0 0 !important;
+            border-top: transparent !important;
+            border: 1px solid transparent !important;
+            transition: borderRadius var(--easing-timing-fast) var(--easing-curve-in),
+                transform var(--easing-timing-fast) var(--easing-curve-in);
+            will-change: borderRadius;
+        }
+        .action-item {
+            overflow: hidden;
+            position: relative;
+            z-index: 1;
+        }
+    }
+
+    > .content {
+        background: var(--noise-bg) repeat var(--card-bg) !important;
+        border-radius: var(--border-radius);
+        padding: var(--s2) var(--s3) 0;
+        width: calc(100% - var(--s4)) !important;
+    }
+}
+
+.part.auxiliarybar.left {
+    margin-left: var(--s4) !important;
+}
+
+.part.auxiliarybar.right {
+    margin-right: var(--s4) !important;
 }
 
 :root {


### PR DESCRIPTION
This PR adds full styling support for the **secondary (auxiliary) sidebar** to better align it with the Fluent UI design system.

## Changes

* Styled the secondary sidebar with custom Fluent UI theming
* Applied a transparent background using exclusion blend mode
* Added rounded corners and padding based on design tokens
* Introduced smooth transitions for interactive elements
* Ensured consistent margins across both left and right sidebars

These adjustments help the secondary sidebar visually integrate with the rest of the UI and maintain a cohesive layout.

## Screenshots

| Before | After |
|-------|-------|
| ![Before](https://github.com/user-attachments/assets/f843ccd4-21fa-4297-a480-a7479dd6759b) | ![After](https://github.com/user-attachments/assets/99f5632e-49b4-4f87-9968-7c3396fefbc9) 

## Related Issue

Resolves: #56 
